### PR TITLE
configure.ac: Use a function prototype for _ linkage probing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1313,12 +1313,10 @@ AC_LANG_PUSH([C])
 dnl check whether one can link against Fortran programs from C
 AC_MSG_CHECKING(whether we need _ in C programs to link against a Fortran library)
 AC_LINK_IFELSE([AC_LANG_SOURCE([
-int main(int argc, char **argv) {
+char dgemm_(void);
 
-  int m, n, k, lda, ldb, ldc;
-  double alpha, beta;
-  double *a, *b, *c;
-  dgemm_("N", "N", &m, &n, &k, &alpha, a, lda, b, &ldb, &beta, c, &ldc);
+int main(int argc, char **argv) {
+  return dgemm_();
 }
  ])],
    [can_link_with_=yes],
@@ -1331,12 +1329,10 @@ fi
 
 AC_MSG_CHECKING(whether we can link C programs against Fortran without _ )
 AC_LINK_IFELSE([AC_LANG_SOURCE([
-int main(int argc, char **argv) {
+char dgemm(void);
 
-  int m, n, k, lda, ldb, ldc;
-  double alpha, beta;
-  double *a, *b, *c;
-  dgemm("N", "N", &m, &n, &k, &alpha, a, lda, b, &ldb, &beta, c, &ldc);
+int main(int argc, char **argv) {
+  return dgemm();
 }
  ])],
    [can_link_without_=yes],


### PR DESCRIPTION
The prototype chosen (char return type, no arguments) follows the usual autoconf approach for link tests.  This is why compilers are likely to continue to support this construct even if there is a mismatch in types.

Future compilers are likely to reject implicit function declarations, and the checks will always fail with such compilers.  (Implicit function declarations were removed from C in 1999.)

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC