### PR TITLE
Fix confusing notice messages in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2983,7 +2983,7 @@ if test x"$need_nvidia_gpu" = x"yes"; then
     echo ""
     echo ""
     echo ""
-    AC_MSG_NOTICE([If --enable-nvidia-gpu is set, we recommend --enable-gpu-streams-nvidia])
+    AC_MSG_NOTICE([If --enable-nvidia-gpu is set, we recommend --enable-gpu-streams=nvidia])
   fi
 fi
 
@@ -3015,7 +3015,7 @@ if test x"$need_amd_gpu" = x"yes"; then
     echo ""
     echo ""
     echo ""
-    AC_MSG_NOTICE([If --enable-amd-gpu is set, we recommend --enable-gpu-streams-amd])
+    AC_MSG_NOTICE([If --enable-amd-gpu is set, we recommend --enable-gpu-streams=amd])
   fi
 fi
 


### PR DESCRIPTION
When I tried to build this library, I got a helpful warning, but the message was slightly confusing. So I fixed it.